### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ rpcallowip=<your bot's ip address or just 127.0.0.1 if hosted on the same machin
 To run the bot simply use `node bin/tipbot` or `npm start`.
 
 ## Commands
+Commands are executed by messaging the bot. Commands that have channel:true in the config can be run with '!<command>' in the channel.
 
 | **Command** | **Arguments**     | **Description**
 |-------------|-------------------|--------------------------------------------------------------------


### PR DESCRIPTION
Readme did not show how to run commands. No where does it say to prefix the command with '!' to message the bot in the channel. In addition to this, the '!' should be configurable in the event that there exists more than one bot in a channel.
